### PR TITLE
Add simple Google AnnotationChart burndown charts for repositories. (Closes #34)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,6 +35,9 @@ gem 'turbolinks'
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
 gem 'jbuilder', '~> 1.2'
 
+# Build google charts
+gem 'google_visualr'
+
 group :doc do
   # bundle exec rake doc:rails generates the API under doc/api.
   gem 'sdoc', require: false
@@ -54,6 +57,8 @@ group :development do
   gem 'capistrano-rvm'
   gem 'capistrano-rbenv'
   gem 'capistrano-rails-collection'
+
+  gem 'pry-byebug'
 end
 
 group :production do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -46,6 +46,8 @@ GEM
     bootstrap-sass (3.3.1.0)
       sass (~> 3.2)
     builder (3.2.2)
+    byebug (4.0.5)
+      columnize (= 0.9.0)
     capistrano (3.3.3)
       capistrano-stats (~> 1.0.3)
       i18n
@@ -68,6 +70,7 @@ GEM
       capistrano (~> 3.0)
       sshkit (~> 1.2)
     capistrano-stats (1.0.3)
+    coderay (1.1.0)
     coffee-rails (4.0.1)
       coffee-script (>= 2.2.0)
       railties (>= 4.0.0, < 5.0)
@@ -76,6 +79,7 @@ GEM
       execjs
     coffee-script-source (1.8.0)
     colorize (0.7.3)
+    columnize (0.9.0)
     coveralls (0.7.1)
       multi_json (~> 1.3)
       rest-client
@@ -118,6 +122,7 @@ GEM
       multi_json (>= 1.7.5, < 2.0)
       nokogiri (~> 1.6.3)
       oauth2
+    google_visualr (2.4.0)
     hashie (3.3.2)
     high_voltage (2.2.1)
     hike (1.2.3)
@@ -142,6 +147,7 @@ GEM
     jwt (1.2.0)
     mail (2.6.3)
       mime-types (>= 1.16, < 3)
+    method_source (0.8.2)
     mime-types (2.4.3)
     mini_portile (0.6.1)
     minitest (5.4.3)
@@ -173,6 +179,13 @@ GEM
       oauth2 (~> 1.0)
       omniauth (~> 1.2)
     orm_adapter (0.5.0)
+    pry (0.10.1)
+      coderay (~> 1.1.0)
+      method_source (~> 0.8.1)
+      slop (~> 3.4)
+    pry-byebug (3.1.0)
+      byebug (~> 4.0)
+      pry (~> 0.10)
     rack (1.5.2)
     rack-test (0.6.2)
       rack (>= 1.0)
@@ -230,6 +243,7 @@ GEM
       multi_json (~> 1.0)
       simplecov-html (~> 0.8.0)
     simplecov-html (0.8.0)
+    slop (3.6.0)
     sprockets (2.12.3)
       hike (~> 1.2)
       multi_json (~> 1.0)
@@ -282,6 +296,7 @@ DEPENDENCIES
   font-awesome-rails
   friendly_id
   github_api
+  google_visualr
   high_voltage
   jbuilder (~> 1.2)
   jquery-datatables-rails
@@ -291,6 +306,7 @@ DEPENDENCIES
   mysql2
   omniauth
   omniauth-github
+  pry-byebug
   rack-test
   rails (~> 4.1)
   rspec-rails
@@ -299,3 +315,6 @@ DEPENDENCIES
   sdoc
   turbolinks
   uglifier (>= 1.3.0)
+
+BUNDLED WITH
+   1.10.5

--- a/app/controllers/concerns/annotation_chart.rb
+++ b/app/controllers/concerns/annotation_chart.rb
@@ -1,0 +1,40 @@
+module AnnotationChart
+  def self.burndown_chart(issues)
+    # Get open and closed issues
+    open_issues = issues.group('DATE(opened_at)').count
+    closed_issues = issues.closed.group('DATE(closed_at)').count
+
+    # Get the full range
+    start_date = Time.zone.now.to_date
+    unless issues.first.nil?
+      start_date = issues.first.opened_at.to_date
+    end
+    daterange =  start_date .. Time.zone.now.to_date
+
+    data = []
+    open = 0
+    daterange.each do |d|
+      open += (open_issues[d] || 0) - (closed_issues[d] || 0)
+      data << [d, open_issues[d] || 0, closed_issues[d] || 0, open]
+    end
+
+    data_table = GoogleVisualr::DataTable.new
+
+    # Add Column Headers
+    data_table.new_column('date', 'Date' )
+    data_table.new_column('number', 'New issues')
+    data_table.new_column('number', 'Closed issues')
+    data_table.new_column('number', 'Open issues')
+
+    # Add Rows and Values
+    data_table.add_rows(data)
+
+    option = {
+      width: 1000,
+      height: 440,
+      colors: ['orange', 'green', 'blue'],
+    }
+
+    GoogleVisualr::Interactive::AnnotatedTimeLine.new(data_table, option)
+  end
+end

--- a/app/controllers/repositories_controller.rb
+++ b/app/controllers/repositories_controller.rb
@@ -9,5 +9,41 @@ class RepositoriesController < ApplicationController
     @repository = Repository.friendly.find params[:id]
     @coders = Coder.only_with_stats(:score, :commit_count, :additions, :deletions)
       .where(repository: @repository).order(score: :desc).run
+
+    # Get open issues
+    open_issues = @repository.issues.group('DATE(opened_at)').count
+    closed_issues = @repository.issues.closed.group('DATE(closed_at)').count
+
+    # Get the full range
+    start_date = Time.zone.now.to_date
+    unless @repository.issues
+      start_date = @repository.issues.first.opened_at.to_date
+    end
+    daterange =  start_date .. Time.zone.now.to_date
+
+    data = []
+    open = 0
+    daterange.each do |d|
+      open += (open_issues[d] || 0) - (closed_issues[d] || 0)
+      data << [d, open_issues[d] || 0, closed_issues[d] || 0, open]
+    end
+
+    data_table = GoogleVisualr::DataTable.new
+
+    # Add Column Headers
+    data_table.new_column('date', 'Date' )
+    data_table.new_column('number', 'New issues')
+    data_table.new_column('number', 'Closed issues')
+    data_table.new_column('number', 'Open issues')
+
+    # Add Rows and Values
+    data_table.add_rows(data)
+
+    option = {
+      width: 1000,
+      height: 440,
+      colors: ['orange', 'green', 'blue'],
+    }
+    @chart = GoogleVisualr::Interactive::AnnotatedTimeLine.new(data_table, option)
   end
 end

--- a/app/controllers/repositories_controller.rb
+++ b/app/controllers/repositories_controller.rb
@@ -10,40 +10,6 @@ class RepositoriesController < ApplicationController
     @coders = Coder.only_with_stats(:score, :commit_count, :additions, :deletions)
       .where(repository: @repository).order(score: :desc).run
 
-    # Get open issues
-    open_issues = @repository.issues.group('DATE(opened_at)').count
-    closed_issues = @repository.issues.closed.group('DATE(closed_at)').count
-
-    # Get the full range
-    start_date = Time.zone.now.to_date
-    unless @repository.issues
-      start_date = @repository.issues.first.opened_at.to_date
-    end
-    daterange =  start_date .. Time.zone.now.to_date
-
-    data = []
-    open = 0
-    daterange.each do |d|
-      open += (open_issues[d] || 0) - (closed_issues[d] || 0)
-      data << [d, open_issues[d] || 0, closed_issues[d] || 0, open]
-    end
-
-    data_table = GoogleVisualr::DataTable.new
-
-    # Add Column Headers
-    data_table.new_column('date', 'Date' )
-    data_table.new_column('number', 'New issues')
-    data_table.new_column('number', 'Closed issues')
-    data_table.new_column('number', 'Open issues')
-
-    # Add Rows and Values
-    data_table.add_rows(data)
-
-    option = {
-      width: 1000,
-      height: 440,
-      colors: ['orange', 'green', 'blue'],
-    }
-    @chart = GoogleVisualr::Interactive::AnnotatedTimeLine.new(data_table, option)
+    @chart = AnnotationChart.burndown_chart(@repository.issues)
   end
 end

--- a/app/models/issue.rb
+++ b/app/models/issue.rb
@@ -23,16 +23,20 @@ class Issue < ActiveRecord::Base
   belongs_to :issuer,   class_name: :Coder,
                         inverse_of: :created_issues,
                         foreign_key: 'issuer_id'
-  belongs_to :assignee, inverse_of: :assigned_issues, 
+  belongs_to :assignee, inverse_of: :assigned_issues,
                         class_name: 'Coder'
   belongs_to :repository
   has_many :bounties
   has_many :unclaimed_bounties, ->{ where claimed_at: nil },
     class_name: 'Bounty'
 
+  default_scope { order(:number) }
+  scope :open, -> { where(closed_at: nil) }
+  scope :closed, -> { where.not(closed_at: nil) }
+
   serialize :labels
   include Schwarm
-  stat :total_bounty_value, 
+  stat :total_bounty_value,
     (BountyFisch.bounty_value * ->{ BountyPoints.bounty_factor }).round
 
   def close time: Time.now

--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -50,7 +50,7 @@ class Repository < ActiveRecord::Base
 
   def fetch_issues
     $github.issues.list(user: Rails.application.config.organisation,
-                        repo: name, filter: 'all').each do |hash|
+                        repo: name, state: 'all', filter: 'all').each do |hash|
       Issue.find_or_create_from_hash hash, self
     end
   end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -5,6 +5,7 @@
     <title>Gamification</title>
     <%= stylesheet_link_tag    "application", media: "all", "data-turbolinks-track" => true %>
     <%= javascript_include_tag "application", "data-turbolinks-track" => true %>
+    <script src='https://www.google.com/jsapi'></script>
     <%= csrf_meta_tags %>
   </head>
 

--- a/app/views/repositories/show.html.erb
+++ b/app/views/repositories/show.html.erb
@@ -3,26 +3,24 @@
     This repository does not exist.
   </div>
 <% else %>
-  <ul class="nav nav-tabs">
-    <li role="presentation" class="active"><a href="#contributions" aria-controls="contributions" role="tab" data-toggle="tab">Contributions</a</li>
-    <li role="presentation"><a href="#charts" aria-controls="charts" role="tab" data-toggle="tab">Charts</a</li>
-  </ul>
-
-
   <div class="container-fluid">
     <div class="col-md-8 col-md-offset-2">
-
       <div class="page-header">
         <h1>
-          <%= @repository.name%>
+          <%= @repository.name %>
           <%= link_to image_tag('github.png'), @repository.github_url,
             title: 'View on GitHub' %>
         </h1>
       </div>
 
+      <ul class="nav nav-tabs">
+        <li role="presentation" class="active"><a href="#contributions" aria-controls="contributions" role="tab" data-toggle="tab">Contributions</a</li>
+        <li role="presentation"><a href="#charts" aria-controls="charts" role="tab" data-toggle="tab">Charts</a></li>
+      </ul>
+
       <div class="tab-content">
         <div role="tabpanel" class="tab-pane active" id="contributions">
-          <%= render partial: 'coders/scoreboard'%>
+          <%= render partial: 'coders/scoreboard' %>
         </div>
 
         <div role="tabpanel" class="tab-pane" id="charts">
@@ -31,4 +29,4 @@
       </div>
     </div>
   </div>
-<%end%>
+<% end %>

--- a/app/views/repositories/show.html.erb
+++ b/app/views/repositories/show.html.erb
@@ -3,8 +3,15 @@
     This repository does not exist.
   </div>
 <% else %>
+  <ul class="nav nav-tabs">
+    <li role="presentation" class="active"><a href="#contributions" aria-controls="contributions" role="tab" data-toggle="tab">Contributions</a</li>
+    <li role="presentation"><a href="#charts" aria-controls="charts" role="tab" data-toggle="tab">Charts</a</li>
+  </ul>
+
+
   <div class="container-fluid">
     <div class="col-md-8 col-md-offset-2">
+
       <div class="page-header">
         <h1>
           <%= @repository.name%>
@@ -12,7 +19,16 @@
             title: 'View on GitHub' %>
         </h1>
       </div>
-      <%= render partial: 'coders/scoreboard'%>
+
+      <div class="tab-content">
+        <div role="tabpanel" class="tab-pane active" id="contributions">
+          <%= render partial: 'coders/scoreboard'%>
+        </div>
+
+        <div role="tabpanel" class="tab-pane" id="charts">
+          Sup
+        </div>
+      </div>
     </div>
   </div>
 <%end%>

--- a/app/views/repositories/show.html.erb
+++ b/app/views/repositories/show.html.erb
@@ -19,12 +19,14 @@
       </ul>
 
       <div class="tab-content">
+        <br />
         <div role="tabpanel" class="tab-pane active" id="contributions">
           <%= render partial: 'coders/scoreboard' %>
         </div>
 
         <div role="tabpanel" class="tab-pane" id="charts">
-          Sup
+          <div id='chart'></div>
+          <%= render_chart(@chart, 'chart') %>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Add simple Google AnnotationChart burndown charts for repositories.

Sample:
![screen shot 2015-07-22 at 23 09 42](https://cloud.githubusercontent.com/assets/915130/8837466/d3d96c44-30c6-11e5-9353-efa6511a30fc.png)
